### PR TITLE
[WEB-187] Image Thumbnail preview issue on strapi admin panel

### DIFF
--- a/config/middlewares.js
+++ b/config/middlewares.js
@@ -15,7 +15,7 @@
                 'data:',
                 'blob:',
                 'dl.airtable.com',
-                'xxx-strapi.s3.amazonaws.com',
+                '*.amazonaws.com',
               ],
               'media-src': [
                 "'self'",


### PR DESCRIPTION
Update AWS S3 domain in middlewares configuration to show image previews:
<img width="766" alt="image" src="https://github.com/user-attachments/assets/7c470534-d958-4bc5-802c-ed2aace1345b">
