### PR TITLE
[WEB-187] Allow image previews from strapi server

### DIFF
--- a/config/middlewares.js
+++ b/config/middlewares.js
@@ -16,6 +16,7 @@
                 'blob:',
                 'dl.airtable.com',
                 '*.amazonaws.com',
+                '*.media.strapiapp.com',
               ],
               'media-src': [
                 "'self'",
@@ -23,6 +24,7 @@
                 'blob:',
                 'dl.airtable.com',
                 '*.amazonaws.com',
+                '*.media.strapiapp.com',
               ]
             },
           },


### PR DESCRIPTION
Update middlewares configuration to allow image previews from *.media.strapiapp.com