### PR TITLE
add support for upcoming tokens

### DIFF
--- a/src/api/ecosystem/content-types/ecosystem/schema.json
+++ b/src/api/ecosystem/content-types/ecosystem/schema.json
@@ -39,6 +39,17 @@
       "type": "string",
       "required": true,
       "unique": true
+    },
+    "homepageDescription": {
+      "type": "string"
+    },
+    "activeToken": {
+      "type": "boolean",
+      "default": false
+    },
+    "featuredEcosystem": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/src/api/home-page-entry/content-types/home-page-entry/schema.json
+++ b/src/api/home-page-entry/content-types/home-page-entry/schema.json
@@ -21,6 +21,11 @@
       "type": "component",
       "repeatable": true,
       "component": "announcement.announcement"
+    },
+    "upcomingTokens": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::ecosystem.ecosystem"
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -921,6 +921,9 @@ export interface ApiEcosystemEcosystem extends Schema.CollectionType {
     ecosystemDescription: Attribute.Text & Attribute.Required;
     ecosystemSlug: Attribute.String & Attribute.Required & Attribute.Unique;
     ecosystemCoinId: Attribute.String & Attribute.Required & Attribute.Unique;
+    homepageDescription: Attribute.String;
+    activeToken: Attribute.Boolean & Attribute.DefaultTo<false>;
+    featuredEcosystem: Attribute.Boolean & Attribute.DefaultTo<false>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -957,6 +960,11 @@ export interface ApiHomePageEntryHomePageEntry extends Schema.SingleType {
       'api::article-entry.article-entry'
     >;
     announcements: Attribute.Component<'announcement.announcement', true>;
+    upcomingTokens: Attribute.Relation<
+      'api::home-page-entry.home-page-entry',
+      'oneToMany',
+      'api::ecosystem.ecosystem'
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;


### PR DESCRIPTION
- new "upcomingTokens" field on homepage entry
- new "homepageDescription" field on ecosystem entry (description that will appear on the homepage card)
- new "activeToken" field on ecosystem entry (boolean indicating if ecosystem page is ready so we can redirect the user from the homepage to this ecosystem page)
- new "featuredEcosystem" field on ecosystem entry (boolean indicating wether an ecosystem should be shown as "hot" on homepage)